### PR TITLE
Przeskalowanie obrazów typu gif

### DIFF
--- a/code/GraphicsGenerator.c
+++ b/code/GraphicsGenerator.c
@@ -143,7 +143,7 @@ void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int 
     ge_close_gif(gif); //Free memory
 }
 
-Pixel* upscaleImage(const Pixel* original, int imageX, int imageY)
+Pixel* upscaleImage(const Pixel* original, int imageX, int imageY, int* newX, int* newY)
 {
     int max = (imageX > imageY) ? imageX : imageY;
 
@@ -151,21 +151,23 @@ Pixel* upscaleImage(const Pixel* original, int imageX, int imageY)
     if (max >= MIN_IMAGE_SIZE)
         multiplier = 1;
 
-    int newX = imageX*multiplier;
-    int newY = imageY*multiplier;
+    int newXdim = imageX*multiplier;
+    int newYdim = imageY*multiplier;
 
-    Pixel* resizedImage = malloc(newX * newY * sizeof(*resizedImage));
-    for(int i = 0; i < newY; i++)
+    Pixel* resizedImage = malloc(newXdim * newYdim * sizeof(*resizedImage));
+    for(int i = 0; i < newYdim; i++)
     {
-        for(int j = 0; j < newX; j++)
+        for(int j = 0; j < newXdim; j++)
         {
-            int xIndex = j*imageX/newX;
-            int yIndex = i*imageY/newY;
+            int xIndex = j*imageX/newXdim;
+            int yIndex = i*imageY/newYdim;
 
-            resizedImage[i*newX + j] = original[yIndex*imageX + xIndex];
+            resizedImage[i*newXdim + j] = original[yIndex*imageX + xIndex];
         }
-        
     }
+
+    *newX = newXdim;
+    *newY = newYdim;
 
     return resizedImage;
 }

--- a/code/GraphicsGenerator.c
+++ b/code/GraphicsGenerator.c
@@ -113,7 +113,7 @@ void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int 
     ge_GIF* gif = ge_new_gif(
         outputFile,     //File name
         width, heigth,  //Gif size
-        (uint8_t []) {  //Color palet
+        (uint8_t []) {  //Color pallet
             0x00, 0x00, 0x00, // 0 -> black
             0xFF, 0xFF, 0xFF, // 1 -> white
         },
@@ -141,4 +141,31 @@ void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int 
     }
 
     ge_close_gif(gif); //Free memory
+}
+
+Pixel* upscaleImage(const Pixel* original, int imageX, int imageY)
+{
+    int max = (imageX > imageY) ? imageX : imageY;
+
+    int multiplier = ceil((double) MIN_IMAGE_SIZE / (double) max);
+    if (max >= MIN_IMAGE_SIZE)
+        multiplier = 1;
+
+    int newX = imageX*multiplier;
+    int newY = imageY*multiplier;
+
+    Pixel* resizedImage = malloc(newX * newY * sizeof(*resizedImage));
+    for(int i = 0; i < newY; i++)
+    {
+        for(int j = 0; j < newX; j++)
+        {
+            int xIndex = j*imageX/newX;
+            int yIndex = i*imageY/newY;
+
+            resizedImage[i*newX + j] = original[yIndex*imageX + xIndex];
+        }
+        
+    }
+
+    return resizedImage;
 }

--- a/code/GraphicsGenerator.c
+++ b/code/GraphicsGenerator.c
@@ -106,8 +106,9 @@ void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int 
     if (numberOfBoards < 1)
         return;
 
-    int width = boards[0]->sizeX;
-    int heigth = boards[0]->sizeY;
+    int width;
+    int heigth;
+    getUpscaledImageSize(boards[0]->sizeX, boards[0]->sizeY, &width, &heigth);
 
     //Create gif
     ge_GIF* gif = ge_new_gif(
@@ -125,22 +126,51 @@ void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int 
     for (int n = 0; n < numberOfBoards; n++)
     {
         Board* currentBoard = boards[n];
+        Pixel normalImage[currentBoard->sizeX * currentBoard->sizeY];
 
-        //Set pixels of next frame
-        for (int i = 0; i < heigth; i++)
+        //Set pixels of normal image
+        for (int i = 0; i < currentBoard->sizeY; i++)
         {
-            for (int j = 0; j < width; j++)
+            for (int j = 0; j < currentBoard->sizeX; j++)
             {
-                int index = i * width + j;
+                int index = i * currentBoard->sizeX + j;
                 CellState state = currentBoard->cells[index];
-                gif->frame[index] = (state == DEAD) ? 0 : 1;
+                normalImage[index] = (state == DEAD) ? 0 : 1;
             }
         }
+
+        int x, y;
+        Pixel* scaledImage = upscaleImage(normalImage, currentBoard->sizeX, currentBoard->sizeY, &x, &y);
+
+        // Set frame pixels
+        for (int i = 0; i < y; i++)
+        {
+            for (int j = 0; j < x; j++)
+            {
+                int index = i * width + j;
+                gif->frame[index] = scaledImage[index];
+            }
+        }
+
+        free(scaledImage);
+
         //Save frame
         ge_add_frame(gif, delay);
     }
 
     ge_close_gif(gif); //Free memory
+}
+
+void getUpscaledImageSize(int orginalX, int orginalY, int* newX, int* newY)
+{
+    int max = (orginalX > orginalY) ? orginalX : orginalY;
+
+    int multiplier = ceil((double) MIN_IMAGE_SIZE / (double) max);
+    if (max >= MIN_IMAGE_SIZE)
+        multiplier = 1;
+
+    *newX = orginalX*multiplier;
+    *newY = orginalY*multiplier;
 }
 
 Pixel* upscaleImage(const Pixel* original, int imageX, int imageY, int* newX, int* newY)

--- a/code/GraphicsGenerator.h
+++ b/code/GraphicsGenerator.h
@@ -20,6 +20,9 @@ void savePng(Board* board, char* outputFile);
 // Each board must have the same size
 void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int delay);
 
+// Calculates size of upscaled image
+void getUpscaledImageSize(int orginalX, int orginalY, int* newX, int* newY);
+
 // Creates upscaled version of given image
 // At the longest dimension
 // Upscaled image size is written to newX and newY arguents

--- a/code/GraphicsGenerator.h
+++ b/code/GraphicsGenerator.h
@@ -21,6 +21,7 @@ void savePng(Board* board, char* outputFile);
 void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int delay);
 
 // Creates upscaled version of given image
-// At the longest dimension 
+// At the longest dimension
+// Upscaled image size is written to newX and newY arguents
 // Returned array must be feed
-Pixel* upscaleImage(const Pixel* original, int imageX, int imageY);
+Pixel* upscaleImage(const Pixel* original, int imageX, int imageY, int* newX, int* newY);

--- a/code/GraphicsGenerator.h
+++ b/code/GraphicsGenerator.h
@@ -6,8 +6,12 @@
 #include <string.h>
 #include <stdarg.h>
 #include <png.h>
+#include <math.h>
 #include "Board.h"
 #include "gifenc.h"
+
+#define MIN_IMAGE_SIZE 600//Used for image upscaling
+typedef int Pixel;
 
 // Saves image representation of given board to specified file
 void savePng(Board* board, char* outputFile);
@@ -15,3 +19,8 @@ void savePng(Board* board, char* outputFile);
 // Saves series of board states into one .gif file
 // Each board must have the same size
 void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int delay);
+
+// Creates upscaled version of given image
+// At the longest dimension 
+// Returned array must be feed
+Pixel* upscaleImage(const Pixel* original, int imageX, int imageY);


### PR DESCRIPTION
Funkcje powiększające obraz do wartości jednej krawędzi co najmniej równej stałej `MIN_IMAGE_SIZE`

Funkcje te zostały zastosowane do powiększania obrazów typu _gif_.  
**Nie jest** jeszcze zrobione powiększanie _jpg_.