### PR TITLE
Refaktoryzacja skalowania i skalowanie png

### DIFF
--- a/code/GraphicsGenerator.c
+++ b/code/GraphicsGenerator.c
@@ -5,8 +5,15 @@ void savePng(Board *board, char *outputFile)
     //Set up setting
     png_byte color_type = PNG_COLOR_TYPE_GRAY;
     png_byte bit_depth = 8;
-    int width = board->sizeX;
-    int height = board->sizeY;
+
+
+    int width;
+    int height;
+    getUpscaledImageSize(board->sizeX, board->sizeY, &width, &height);
+
+    Pixel* orginalImage = translateBoardToPixels(board, 255, 0);
+    Pixel* scaledImage = upscaleImage(orginalImage, board->sizeX, board->sizeY);
+    free(orginalImage);
 
     png_bytep *row_pointers = (png_bytep *)malloc(sizeof(png_bytep) * height);
     for (int y = 0; y < height; y++)
@@ -17,10 +24,10 @@ void savePng(Board *board, char *outputFile)
         png_byte *row = row_pointers[y];
         for (int x = 0; x < width; x++)
         {
-            CellState cell = board->cells[y * board->sizeX + x];
-            row[x] = (cell == ALIVE) ? 255 : 0;
+            row[x] = scaledImage[y * width + x];
         }
     }
+    free(scaledImage);
 
     //Writing to file
     FILE *fp = fopen(outputFile, "wb");

--- a/code/GraphicsGenerator.h
+++ b/code/GraphicsGenerator.h
@@ -10,21 +10,27 @@
 #include "Board.h"
 #include "gifenc.h"
 
-#define MIN_IMAGE_SIZE 600//Used for image upscaling
+#define MIN_IMAGE_SIZE 600 //Used for image upscaling
 typedef int Pixel;
 
 // Saves image representation of given board to specified file
-void savePng(Board* board, char* outputFile);
+void savePng(Board *board, char *outputFile);
 
 // Saves series of board states into one .gif file
 // Each board must have the same size
-void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int delay);
+void saveHistoryAsGif(Board **boards, int numberOfBoards, char *outputFile, int delay);
+
+// Changes board object to Pixel array as instructed by valueOfAlive, valueOfDead
+// Each ALIVE cell will have Pixel value of valueOfAlive
+// Each DEAD cell will have Pixel value of valueOfDead
+// // Returned array must be freed
+Pixel *translateBoardToPixels(Board *board, Pixel valueOfAlive, Pixel valueOfDead);
 
 // Calculates size of upscaled image
 // Results are put to variables pointed by newX and newY
-void getUpscaledImageSize(int orginalX, int orginalY, int* newX, int* newY);
+void getUpscaledImageSize(int orginalX, int orginalY, int *newX, int *newY);
 
 // Creates upscaled version of given image
 // Longest edge determines size
-// Returned array must be feed
-Pixel* upscaleImage(const Pixel* original, int imageX, int imageY);
+// Returned array must be freed
+Pixel *upscaleImage(const Pixel *original, int imageX, int imageY);

--- a/code/GraphicsGenerator.h
+++ b/code/GraphicsGenerator.h
@@ -21,10 +21,10 @@ void savePng(Board* board, char* outputFile);
 void saveHistoryAsGif(Board** boards, int numberOfBoards, char* outputFile, int delay);
 
 // Calculates size of upscaled image
+// Results are put to variables pointed by newX and newY
 void getUpscaledImageSize(int orginalX, int orginalY, int* newX, int* newY);
 
 // Creates upscaled version of given image
-// At the longest dimension
-// Upscaled image size is written to newX and newY arguents
+// Longest edge determines size
 // Returned array must be feed
-Pixel* upscaleImage(const Pixel* original, int imageX, int imageY, int* newX, int* newY);
+Pixel* upscaleImage(const Pixel* original, int imageX, int imageY);

--- a/code/main.c
+++ b/code/main.c
@@ -75,6 +75,7 @@ void runProgram(int argc, char **args)
    }
 
    Board **history = simulate(initialBoard, config);
+   //FIXME: Move size calculation to function
    int historySize = (config->number_of_generations % config->step == 0) ? config->number_of_generations / config->step : config->number_of_generations / config->step + 1;
 
    switch (config->type)


### PR DESCRIPTION
## Zmiany istniejącego kodu
Obliczanie rozmiaru przeskalowanego obrazu zostało **całkowicie wydzielone** do oddzielnej funkcji. 
Zamiana planszy na tablicę pikseli została wydzielona do oddzielnej funkcji.   
Większy porządek w `saveHistoryAsGif`.

## Nowości
Obrazy generowane przez`savePng` są przeskalowywane tak jak gify.

------------------------------
Closes #9
Po margeu można bezpiecznie **usunąć brancha** 💣