### PR TITLE
Dodanie nowych testów jednostkowych

### DIFF
--- a/code/RulesTest.c
+++ b/code/RulesTest.c
@@ -63,3 +63,19 @@ void testNextStateAliveDiesFromLoneliness()
     //Then
     CU_ASSERT_EQUAL(futureState, DEAD);
 }
+
+void testNextStateAliveStaysAlive()
+{
+    //Given
+    CellState states[] = {ALIVE, DEAD, DEAD,
+                          DEAD, ALIVE, ALIVE,
+                          ALIVE, DEAD, DEAD};
+    CellState *area = malloc(SIZE * sizeof(*area));
+    memcpy(area, states, SIZE * sizeof(*area));
+
+    //When
+    CellState futureState = nextState(area);
+
+    //Then
+    CU_ASSERT_EQUAL(futureState, ALIVE);
+}

--- a/code/RulesTest.c
+++ b/code/RulesTest.c
@@ -15,3 +15,19 @@ void testNextStateDeadStaysDead()
     //Then
     CU_ASSERT_EQUAL(futureState, DEAD);
 }
+
+void testNextStateDeadComesToLive()
+{
+    //Given
+    CellState states[] = {ALIVE, ALIVE, DEAD,
+                          DEAD, DEAD, DEAD,
+                          DEAD, ALIVE, DEAD};
+    CellState *area = malloc(SIZE * sizeof(*area));
+    memcpy(area, states, SIZE * sizeof(*area));
+
+    //When
+    CellState futureState = nextState(area);
+
+    //Then
+    CU_ASSERT_EQUAL(futureState, ALIVE);
+}

--- a/code/RulesTest.c
+++ b/code/RulesTest.c
@@ -1,0 +1,17 @@
+#include "RulesTest.h"
+
+void testNextStateDeadStaysDead()
+{
+    //Given
+    CellState states[] = {ALIVE, ALIVE, DEAD,
+                          ALIVE, DEAD, ALIVE,
+                          DEAD, ALIVE, DEAD};
+    CellState *area = malloc(SIZE * sizeof(*area));
+    memcpy(area, states, SIZE * sizeof(*area));
+
+    //When
+    CellState futureState = nextState(area);
+
+    //Then
+    CU_ASSERT_EQUAL(futureState, DEAD);
+}

--- a/code/RulesTest.c
+++ b/code/RulesTest.c
@@ -31,3 +31,35 @@ void testNextStateDeadComesToLive()
     //Then
     CU_ASSERT_EQUAL(futureState, ALIVE);
 }
+
+void testNextStateAliveDiesFromOverpopulation()
+{
+    //Given
+    CellState states[] = {ALIVE, ALIVE, DEAD,
+                          ALIVE, ALIVE, DEAD,
+                          ALIVE, ALIVE, DEAD};
+    CellState *area = malloc(SIZE * sizeof(*area));
+    memcpy(area, states, SIZE * sizeof(*area));
+
+    //When
+    CellState futureState = nextState(area);
+
+    //Then
+    CU_ASSERT_EQUAL(futureState, DEAD);
+}
+
+void testNextStateAliveDiesFromLoneliness()
+{
+    //Given
+    CellState states[] = {DEAD, DEAD, DEAD,
+                          DEAD, ALIVE, DEAD,
+                          ALIVE, DEAD, DEAD};
+    CellState *area = malloc(SIZE * sizeof(*area));
+    memcpy(area, states, SIZE * sizeof(*area));
+
+    //When
+    CellState futureState = nextState(area);
+
+    //Then
+    CU_ASSERT_EQUAL(futureState, DEAD);
+}

--- a/code/RulesTest.h
+++ b/code/RulesTest.h
@@ -8,3 +8,5 @@
 
 void testNextStateDeadStaysDead();
 void testNextStateDeadComesToLive();
+void testNextStateAliveDiesFromOverpopulation();
+void testNextStateAliveDiesFromLoneliness();

--- a/code/RulesTest.h
+++ b/code/RulesTest.h
@@ -7,3 +7,4 @@
 #include "Rules.h"
 
 void testNextStateDeadStaysDead();
+void testNextStateDeadComesToLive();

--- a/code/RulesTest.h
+++ b/code/RulesTest.h
@@ -10,3 +10,4 @@ void testNextStateDeadStaysDead();
 void testNextStateDeadComesToLive();
 void testNextStateAliveDiesFromOverpopulation();
 void testNextStateAliveDiesFromLoneliness();
+void testNextStateAliveStaysAlive();

--- a/code/RulesTest.h
+++ b/code/RulesTest.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <CUnit/CUnit.h>
+#include <stdlib.h>
+
+#include "Board.h"
+#include "Rules.h"
+
+void testNextStateDeadStaysDead();

--- a/code/SimulatorTest.c
+++ b/code/SimulatorTest.c
@@ -2,5 +2,23 @@
 
 void testSimulateOneNextGenOnSmallBoard()
 {
-    //TODO: Write this test
+    //Given
+    CellState cells[] = {ALIVE, ALIVE,
+                         DEAD, ALIVE};
+    Board board = {.sizeX = 2, .sizeY = 2, .cells = cells};
+
+    //When
+    Board *nextState = nextGen(&board);
+
+    //Then
+    CU_ASSERT_EQUAL(nextState->sizeX, 2);
+    CU_ASSERT_EQUAL(nextState->sizeY, 2);
+
+    CellState expectedCells[] = {ALIVE, ALIVE,
+                                 ALIVE, ALIVE};
+
+    for (int i = 0; i < 4; i++)
+        CU_ASSERT_EQUAL(nextState->cells[i], expectedCells[i]);
+
+    disposeBoard(nextState);
 }

--- a/code/SimulatorTest.c
+++ b/code/SimulatorTest.c
@@ -1,0 +1,6 @@
+#include "SimulatorTest.h"
+
+void testSimulateOneNextGenOnSmallBoard()
+{
+    //TODO: Write this test
+}

--- a/code/SimulatorTest.h
+++ b/code/SimulatorTest.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <CUnit/CUnit.h>
+#include <stdlib.h>
+
+#include "Board.h"
+#include "Simulator.h"
+
+//Test simulator on case from documentation
+void testSimulateOneNextGenOnSmallBoard();

--- a/code/SimulatorTest.h
+++ b/code/SimulatorTest.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include "Board.h"
+#include "BoardHandler.h"
 #include "Simulator.h"
 
 //Test simulator on case from documentation

--- a/code/main.c
+++ b/code/main.c
@@ -24,9 +24,9 @@ void runProgram(int argc, char **args);
 
 int main(int argc, char **args)
 {
-   #ifdef TESTS
-      runTests();
-   #endif
+#ifdef TESTS
+   runTests();
+#endif
 
    //argumenty
    runProgram(argc, args);
@@ -34,7 +34,8 @@ int main(int argc, char **args)
    return EXIT_SUCCESS;
 }
 
-void displayHelp(){
+void displayHelp()
+{
    printf("Gra w życie\n\nParametry:\n");
    printf("%-30s =>             %s\n", "-h / --help", "help");
    printf("%-30s =>             %s\n", "-n / --number_of_generations", "number of created generations (integer)");
@@ -66,37 +67,39 @@ void runProgram(int argc, char **args)
       initialBoard = load(config->file);
    }
 
-   Board** history1 = simulate(initialBoard, config);
+   Board **history1 = simulate(initialBoard, config);
    Board **history = stepSimulate(history1, config);
    //FIXME: Move size calculation to function
    int historySize = (config->number_of_generations + 1) / config->step;
 
    switch (config->type)
    {
-      case GIF:
-         saveAsGif(history, config, historySize);
-         break;
-      case PNG:
-         for(int i = 0; i < historySize; i++){
-            saveAsPng(history, config, i);
-         }
-         break;
+   case GIF:
+      saveAsGif(history, config, historySize);
+      break;
+   case PNG:
+      for (int i = 0; i < historySize; i++)
+      {
+         saveAsPng(history, config, i);
+      }
+      break;
 
-      case TXT:
-         for(int i = 0; i < historySize; i++){
-            saveAsTxt(history, config, i);
-         }
-         break;
-      case OUT:
-         for(int i = 0; i < historySize; i++){
-            printToStdout(history, config, i);
-         }
-         break;
+   case TXT:
+      for (int i = 0; i < historySize; i++)
+      {
+         saveAsTxt(history, config, i);
+      }
+      break;
+   case OUT:
+      for (int i = 0; i < historySize; i++)
+      {
+         printToStdout(history, config, i);
+      }
+      break;
    }
 
-
-   for (int i=0; i<config->number_of_generations + 1; i++)
-         disposeBoard(history1[i]);
+   for (int i = 0; i < config->number_of_generations + 1; i++)
+      disposeBoard(history1[i]);
 
    disposeConfig(config);
 

--- a/code/main.c
+++ b/code/main.c
@@ -15,6 +15,7 @@
 #include <CUnit/Basic.h>
 #include "boardTest.h"
 #include "LoaderTest.h"
+#include "RulesTest.h"
 
 void runTests();
 #endif
@@ -23,21 +24,12 @@ void runProgram(int argc, char **args);
 
 int main(int argc, char **args)
 {
+   #ifdef TESTS
+      runTests();
+   #endif
+
    //argumenty
    runProgram(argc, args);
-
-// #ifdef DEBUG
-//    Config *p = malloc(sizeof(*p));
-//    p->number_of_generations = 20;
-//    p->step = 2;
-//    Board *b = load("input.txt");
-//    Board **bArray = simulate(b, p);
-//    display(bArray, p);
-// #endif
-
-#ifdef TESTSX
-   runTests();
-#endif
 
    return EXIT_SUCCESS;
 }
@@ -144,6 +136,19 @@ void runTests()
    }
 
    if (CU_add_test(loaderSuite, "Parse small file test", testParseSmallFile) == NULL)
+   {
+      CU_cleanup_registry();
+      exit(CU_get_error());
+   }
+
+   CU_pSuite rulesSuite = CU_add_suite("Rules tests", NULL, NULL);
+   if (rulesSuite == NULL)
+   {
+      CU_cleanup_registry();
+      exit(CU_get_error());
+   }
+
+   if (CU_add_test(rulesSuite, "Dead cell stays dead", testNextStateDeadStaysDead) == NULL)
    {
       CU_cleanup_registry();
       exit(CU_get_error());

--- a/code/main.c
+++ b/code/main.c
@@ -16,6 +16,7 @@
 #include "boardTest.h"
 #include "LoaderTest.h"
 #include "RulesTest.h"
+#include "SimulatorTest.h"
 
 void runTests();
 #endif
@@ -157,6 +158,19 @@ void runTests()
          || CU_add_test(rulesSuite, "Alive cell dies from loneliness", testNextStateAliveDiesFromLoneliness) == NULL
          || CU_add_test(rulesSuite, "Alive cell stays alive", testNextStateAliveStaysAlive) == NULL
       )
+   {
+      CU_cleanup_registry();
+      exit(CU_get_error());
+   }
+
+   CU_pSuite simulatorSuite = CU_add_suite("Simulator tests", NULL, NULL);
+   if (simulatorSuite == NULL)
+   {
+      CU_cleanup_registry();
+      exit(CU_get_error());
+   }
+
+   if (CU_add_test(simulatorSuite, "Simulate one next generation on small board", testSimulateOneNextGenOnSmallBoard) == NULL)
    {
       CU_cleanup_registry();
       exit(CU_get_error());

--- a/code/main.c
+++ b/code/main.c
@@ -151,7 +151,9 @@ void runTests()
       exit(CU_get_error());
    }
 
-   if (CU_add_test(rulesSuite, "Dead cell stays dead", testNextStateDeadStaysDead) == NULL)
+   if (CU_add_test(rulesSuite, "Dead cell stays dead", testNextStateDeadStaysDead) == NULL 
+         || CU_add_test(rulesSuite, "Dead cell comes to live", testNextStateDeadComesToLive) == NULL
+      )
    {
       CU_cleanup_registry();
       exit(CU_get_error());

--- a/code/main.c
+++ b/code/main.c
@@ -153,6 +153,8 @@ void runTests()
 
    if (CU_add_test(rulesSuite, "Dead cell stays dead", testNextStateDeadStaysDead) == NULL 
          || CU_add_test(rulesSuite, "Dead cell comes to live", testNextStateDeadComesToLive) == NULL
+         || CU_add_test(rulesSuite, "Alive cell dies from overpopulation", testNextStateAliveDiesFromOverpopulation) == NULL
+         || CU_add_test(rulesSuite, "Alive cell dies from loneliness", testNextStateAliveDiesFromLoneliness) == NULL
       )
    {
       CU_cleanup_registry();

--- a/code/main.c
+++ b/code/main.c
@@ -155,6 +155,7 @@ void runTests()
          || CU_add_test(rulesSuite, "Dead cell comes to live", testNextStateDeadComesToLive) == NULL
          || CU_add_test(rulesSuite, "Alive cell dies from overpopulation", testNextStateAliveDiesFromOverpopulation) == NULL
          || CU_add_test(rulesSuite, "Alive cell dies from loneliness", testNextStateAliveDiesFromLoneliness) == NULL
+         || CU_add_test(rulesSuite, "Alive cell stays alive", testNextStateAliveStaysAlive) == NULL
       )
    {
       CU_cleanup_registry();

--- a/code/makefile
+++ b/code/makefile
@@ -1,5 +1,5 @@
 CC=clang
-DebugFlags=-std=c11 -Wall -g3 -D DEBUG -D TESTS
+DebugFlags=-std=c11 -Wall -g3
 ReleseFlags=-Ofast -std=c11 -g0
 Libraries=cunit libpng
 
@@ -7,19 +7,23 @@ Libraries=cunit libpng
 # It is assumed that each one has .h and .c file
 Objects=BoardHandler.o Loader.o ArgumentsParser.o GraphicsGenerator.o gifenc.o Rules.o Simulator.o Saver.o
 ## Here add names of test modules
-TestObjects=boardTest.o LoaderTest.o
+TestObjects=boardTest.o LoaderTest.o RulesTest.o
 
 NAME=main.exe
 
-development: CompileFlags=$(DebugFlags)
-development: $(Objects) $(TestObjects)
-	$(CC) $(DebugFlags) `pkg-config --cflags --libs $(Libraries)` -o $(NAME) $(Objects) $(TestObjects) main.c
+development: CompileFlags=$(DebugFlags) -D DEBUG
+development: $(Objects)
+	$(CC) $(CompileFlags) `pkg-config --cflags --libs $(Libraries)` -o $(NAME) $(Objects) main.c
 
 release: CompileFlags=$(ReleseFlags)
 release: $(Objects)
-	$(CC) $(ReleseFlags) `pkg-config --cflags --libs $(Libraries)` -o $(NAME) $(Objects) main.c
+	$(CC) $(CompileFlags) `pkg-config --cflags --libs $(Libraries)` -o $(NAME) $(Objects) main.c
 
 rebuild: clean release
+
+tests: CompileFlags=$(DebugFlags) -D TESTS
+tests: $(Objects) $(TestObjects)
+	$(CC) $(CompileFlags) `pkg-config --cflags --libs $(Libraries)` -o $(NAME) $(Objects) $(TestObjects) main.c
 
 clean:
 	rm -rf main.exe.dSYM

--- a/code/makefile
+++ b/code/makefile
@@ -7,7 +7,7 @@ Libraries=cunit libpng
 # It is assumed that each one has .h and .c file
 Objects=BoardHandler.o Loader.o ArgumentsParser.o GraphicsGenerator.o gifenc.o Rules.o Simulator.o Saver.o
 ## Here add names of test modules
-TestObjects=boardTest.o LoaderTest.o RulesTest.o
+TestObjects=boardTest.o LoaderTest.o RulesTest.o SimulatorTest.o
 
 NAME=main.exe
 


### PR DESCRIPTION
## Zmiany w makfile
Dodałem do  **makefile** nowy target do wykonywania testów. Jest on teraz wydzielony od development.  
W nowym targecie **tests** nie jest zdefiniowana stała DEBUG dzięki czemu wychodzi ładny wynik, który można wkleić do sprawka. 😄  
Target _development_ nie uruchamia już testów. Przydało by się by odpalał testy, ale wymagałoby to zmiany przepływu sterowania w funkcji testującej. Raczej nie będzie na to już czasu.

## Dodane testy
* Kilka testów do rules
* Mały test symulacji następnego pokolenia
